### PR TITLE
chore(deps): consolidate all Dependabot updates into one change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       - python
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # pytest-homeassistant-custom-component pins pytest exactly (currently
+      # pytest==9.0.3). Bumping the pytest floor past that pin makes the
+      # install unresolvable and fails CI, so pytest is upgraded only as a
+      # side effect of upgrading pytest-homeassistant-custom-component.
+      - dependency-name: pytest
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,11 +27,11 @@ jobs:
       matrix:
         language: [python, actions]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
           fail-on-severity: high

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -16,7 +16,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # full history — scan every commit
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -16,7 +16,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa  # main @ 2026-04
         with:
           category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -16,5 +16,5 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c  # master @ 2026-04
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: home-assistant/actions/hassfest@e3fb68ebda13d88a0d695082f471ba2c83d025fb  # master @ 2026-04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,8 @@ jobs:
   ruff-mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
           cache: pip

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -25,8 +25,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
       - uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266  # v1.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write  # create the GitHub Release
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
           fi
           echo "manifest version '$manifest_version' matches tag '$TAG_NAME'"
 
-      - uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         with:
           generate_release_notes: true
           # HACS pulls source from the tag archive — no extra assets required.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         python-version: ["3.14"]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/custom_components/parentpay/manifest.json
+++ b/custom_components/parentpay/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/robemmerson/ha-parentpay/issues",
-  "requirements": ["beautifulsoup4>=4.14.3"],
+  "requirements": ["beautifulsoup4>=4.15.0"],
   "version": "2.2"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,12 @@
-beautifulsoup4>=4.14.3
-aiohttp>=3.13.5
-homeassistant>=2026.5.4
+beautifulsoup4>=4.15.0
+aiohttp>=3.14.3
+homeassistant>=2026.8.2
+# pytest is held at 9.0.3: pytest-homeassistant-custom-component pins pytest==9.0.3
+# exactly, so a higher floor makes the install unresolvable. Dependabot's pytest
+# PRs fail CI for this reason and are ignored in .github/dependabot.yml.
 pytest>=9.0.3
-pytest-asyncio>=1.3.0
-pytest-homeassistant-custom-component>=0.13.334
-ruff>=0.15.15
-mypy>=2.1.0
-python-dotenv>=1.2.2
+pytest-asyncio>=1.4.0
+pytest-homeassistant-custom-component>=0.13.356
+ruff>=0.16.3
+mypy>=2.3.1
+python-dotenv>=1.2.3


### PR DESCRIPTION
Supersedes the six open Dependabot PRs (#23–#28) with a single reviewed change, and takes every dependency to the newest release **at least 72 hours old** rather than only the versions Dependabot proposed.

## Dependency updates

| Package | From | To | Dependabot PR |
| --- | --- | --- | --- |
| beautifulsoup4 | 4.14.3 | **4.15.0** | — |
| aiohttp | 3.13.5 | **3.14.3** | #26 |
| homeassistant | 2026.5.4 | **2026.8.2** | #24 (proposed 2026.7.4) |
| pytest-asyncio | 1.3.0 | **1.4.0** | #27 |
| pytest-homeassistant-custom-component | 0.13.334 | **0.13.356** | — |
| ruff | 0.15.15 | **0.16.3** | #23 (proposed 0.16.0) |
| mypy | 2.1.0 | **2.3.1** | — |
| python-dotenv | 1.2.2 | **1.2.3** | — |

`manifest.json` beautifulsoup4 floor raised to `>=4.15.0` to match.

Newer releases exist for homeassistant (2026.8.3), phacc (0.13.357) and ruff (0.16.4), but all three landed inside the 72-hour window and were held back.

## GitHub Actions

SHA bumps taken verbatim from #25 — the diff is byte-identical to that PR:

- `actions/checkout` v7.0.0 → v7.0.1
- `github/codeql-action` (init + analyze) v4.36.2 → v4.37.3
- `actions/setup-python` v6.3.0 → v7.0.0
- `home-assistant/actions/hassfest` master pin refreshed
- `softprops/action-gh-release` v3.0.1 → v3.0.2

## Deliberately excluded: #28 (pytest `>=9.1.1`)

`pytest-homeassistant-custom-component` 0.13.356 pins `pytest==9.0.3` **exactly**, so raising the pytest floor makes the install unresolvable:

```
The conflict is caused by:
    The user requested pytest>=9.1.1
    pytest-homeassistant-custom-component 0.13.356 depends on pytest==9.0.3
```

This is why #28 is the one Dependabot PR whose `pytest` and `ruff-mypy` jobs fail. `pytest` is now added to `ignore` in `.github/dependabot.yml` so it is not reopened — it will move when phacc moves.

## Verification

Clean venv, fresh `pip install -r requirements-dev.txt`:

- install resolves cleanly
- `ruff check` — passes (ruff 0.16.4)
- `mypy custom_components` — passes (mypy 2.3.1, strict)
- `pytest` — 62 passed

## Known-failing check: `audit`

`pip-audit` still fails on `cryptography 48.0.1` (PYSEC-2026-3552/3553/3554). `homeassistant` pins `cryptography==48.0.1` exactly, so it is not fixable from this repo — it needs an upstream HA release.

This is **pre-existing and unrelated to these updates**: the `audit` job has failed on `main` since 2026-07-26, and it fails on all six Dependabot PRs too. This change does clear the previous `pillow 12.2.0` finding (PYSEC-2026-2253/2255) via the homeassistant bump.

If you want the job green in the meantime, the `ignore-vulns` list in `.github/workflows/pip-audit.yml` is where to suppress it — I have left that decision to you rather than silencing a security finding unilaterally.